### PR TITLE
SLING-13186 Migrate to junit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,13 @@
         <!-- Apache Sling -->
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
+            <version>3.5.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
             <version>4.0.6</version>
             <scope>test</scope>
         </dependency>
@@ -155,8 +161,19 @@
         </dependency>
         <!-- testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Engine for JUnit 4 tests (paxexam) -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -167,8 +184,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -178,14 +195,13 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>5.2.0</version>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>4.15.0</version>
+            <version>4.21.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/commons/metrics/internal/BundleMetricsMapperTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/BundleMetricsMapperTest.java
@@ -24,14 +24,16 @@ import java.util.Map;
 
 import com.codahale.metrics.MetricRegistry;
 import org.apache.sling.testing.mock.osgi.MockBundle;
-import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContext;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BundleMetricsMapperTest {
-    @Rule
+@ExtendWith(OsgiContextExtension.class)
+class BundleMetricsMapperTest {
+
     public final OsgiContext context = new OsgiContext();
 
     private MetricRegistry registry = new MetricRegistry();
@@ -39,13 +41,13 @@ public class BundleMetricsMapperTest {
     private BundleMetricsMapper mapper = new BundleMetricsMapper(new MetricsServiceImpl(), registry);
 
     @Test
-    public void defaultDomainName() throws Exception {
+    void defaultDomainName() {
         ObjectName name = mapper.createName("counter", "foo", "bar");
         assertEquals("foo", name.getDomain());
     }
 
     @Test
-    public void mappedName_SymbolicName() throws Exception {
+    void mappedName_SymbolicName() {
         MockBundle bundle = new MockBundle(context.bundleContext());
         bundle.setSymbolicName("com.example");
 
@@ -56,7 +58,7 @@ public class BundleMetricsMapperTest {
     }
 
     @Test
-    public void mappedName_Header() throws Exception {
+    void mappedName_Header() {
         MockBundle bundle = new MockBundle(context.bundleContext());
         bundle.setSymbolicName("com.example");
         bundle.setHeaders(Map.of(BundleMetricsMapper.HEADER_DOMAIN_NAME, "com.test"));

--- a/src/test/java/org/apache/sling/commons/metrics/internal/InternalMetricsServiceFactoryTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/InternalMetricsServiceFactoryTest.java
@@ -24,27 +24,33 @@ import com.codahale.metrics.MetricRegistry;
 import org.apache.sling.commons.metrics.Counter;
 import org.apache.sling.commons.metrics.MetricsService;
 import org.apache.sling.testing.mock.osgi.MockBundle;
-import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContext;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.ServiceRegistration;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class InternalMetricsServiceFactoryTest {
-    @Rule
+@ExtendWith(OsgiContextExtension.class)
+class InternalMetricsServiceFactoryTest {
     public final OsgiContext context = new OsgiContext();
 
     private MetricsServiceImpl serviceImpl = new MetricsServiceImpl();
     private MetricRegistry registry = serviceImpl.getRegistry();
     private BundleMetricsMapper mapper = new BundleMetricsMapper(serviceImpl, registry);
     private InternalMetricsServiceFactory srvFactory = new InternalMetricsServiceFactory(serviceImpl, mapper);
+
+    @SuppressWarnings("unchecked")
     private ServiceRegistration<MetricsService> reg = mock(ServiceRegistration.class);
 
     @Test
-    public void basicWorking() throws Exception {
+    void basicWorking() {
         MetricsService service = srvFactory.getService(cb("foo"), reg);
         service.meter("m1");
         service.timer("t1");
@@ -62,7 +68,7 @@ public class InternalMetricsServiceFactoryTest {
     }
 
     @Test
-    public void unRegistration() throws Exception {
+    void unRegistration() {
         Bundle foo = cb("foo");
         Bundle bar = cb("bar");
         MetricsService srv1 = srvFactory.getService(foo, reg);
@@ -82,7 +88,7 @@ public class InternalMetricsServiceFactoryTest {
         assertFalse(registry.getMeters().containsKey("m1"));
         assertFalse(registry.getCounters().containsKey("c1"));
 
-        assertNotEquals("The MetricsService should not return stale metric references.", c1, serviceImpl.counter("c1"));
+        assertNotEquals(c1, serviceImpl.counter("c1"), "The MetricsService should not return stale metric references.");
         assertTrue(registry.getCounters().containsKey("c1"));
 
         // Metrics from 'bar' bundle should be present

--- a/src/test/java/org/apache/sling/commons/metrics/internal/JSONReporterTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/JSONReporterTest.java
@@ -28,15 +28,15 @@ import com.codahale.metrics.JvmAttributeGaugeSet;
 import com.codahale.metrics.MetricRegistry;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.felix.utils.json.JSONParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class JSONReporterTest {
+class JSONReporterTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void jsonOutput() throws Exception {
+    void jsonOutput() throws Exception {
         MetricRegistry registry = new MetricRegistry();
         registry.meter("test1").mark(5);
         registry.timer("test2").time().close();
@@ -61,7 +61,7 @@ public class JSONReporterTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void nan_value() throws Exception {
+    void nan_value() throws Exception {
         MetricRegistry registry = new MetricRegistry();
 
         registry.register("test", new Gauge<Double>() {
@@ -78,7 +78,8 @@ public class JSONReporterTest {
     private static Map<String, Object> getJSON(MetricRegistry registry) throws IOException {
         StringWriter sw = new StringWriter();
         JSONReporter reporter = JSONReporter.forRegistry(registry)
-                .outputTo(new PrintStream(new WriterOutputStream(sw)))
+                .outputTo(new PrintStream(
+                        WriterOutputStream.builder().setWriter(sw).get()))
                 .build();
         reporter.report();
         reporter.close();

--- a/src/test/java/org/apache/sling/commons/metrics/internal/JmxExporterFactoryTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/JmxExporterFactoryTest.java
@@ -37,25 +37,25 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.apache.sling.commons.metrics.MetricsService;
-import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContext;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContextExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.never;
 
-@RunWith(MockitoJUnitRunner.class)
-public class JmxExporterFactoryTest {
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(OsgiContextExtension.class)
+class JmxExporterFactoryTest {
 
-    @Rule
     public OsgiContext context = new OsgiContext();
 
     @Captor
@@ -103,10 +103,10 @@ public class JmxExporterFactoryTest {
 
     MetricsService metrics;
     NotificationListener listener;
-    SimpleBean mbeans[] = {new SimpleBean(0, 0L), new SimpleBean(1, 1L), new SimpleBean(2, 2L)};
+    SimpleBean[] mbeans = {new SimpleBean(0, 0L), new SimpleBean(1, 1L), new SimpleBean(2, 2L)};
 
-    @Before
-    public void setup()
+    @BeforeEach
+    void setup()
             throws MalformedObjectNameException, InstanceAlreadyExistsException, MBeanRegistrationException,
                     NotCompliantMBeanException, InstanceNotFoundException {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
@@ -123,8 +123,8 @@ public class JmxExporterFactoryTest {
         context.registerService(MetricsService.class, metrics);
     }
 
-    @After
-    public void shutdown() throws MBeanRegistrationException, InstanceNotFoundException, MalformedObjectNameException {
+    @AfterEach
+    void shutdown() throws MBeanRegistrationException, InstanceNotFoundException, MalformedObjectNameException {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         server.unregisterMBean(new ObjectName(OBJECT_NAME_0));
         server.unregisterMBean(new ObjectName(OBJECT_NAME_1));
@@ -132,7 +132,7 @@ public class JmxExporterFactoryTest {
     }
 
     @Test
-    public void test() {
+    void test() {
         Map<String, Object> props = new HashMap<>();
         props.put("objectnames", new String[] {OBJECT_NAME_QUERY});
 
@@ -181,7 +181,7 @@ public class JmxExporterFactoryTest {
     }
 
     @Test
-    public void registerNonExistingMBean() {
+    void registerNonExistingMBean() {
         Map<String, Object> props = new HashMap<>();
         props.put("objectnames", new String[] {"org.apache.sling:type=nonexistent"}); // there is no such mbean
 
@@ -190,7 +190,7 @@ public class JmxExporterFactoryTest {
     }
 
     @Test
-    public void registerInvalidMBean() {
+    void registerInvalidMBean() {
         Map<String, Object> props = new HashMap<>();
         props.put("objectnames", new String[] {"org.apache.sling%type=nonexistent"}); // this is invalid
 
@@ -199,7 +199,7 @@ public class JmxExporterFactoryTest {
     }
 
     @Test
-    public void checkNotificationListener() throws Exception {
+    void checkNotificationListener() throws Exception {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         ObjectName test = new ObjectName("com.example:type=TestMBean");
         server.registerMBean(new SimpleBean(1, 1L), test);

--- a/src/test/java/org/apache/sling/commons/metrics/internal/JmxNotificationListenerTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/JmxNotificationListenerTest.java
@@ -24,16 +24,16 @@ import javax.management.MBeanServerNotification;
 import javax.management.NotificationListener;
 import javax.management.ObjectName;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class JmxNotificationListenerTest {
+class JmxNotificationListenerTest {
 
     JmxExporterFactory exporter = new JmxExporterFactory();
     NotificationListener listener = exporter.listener;
 
     @Test
-    public void testHandleNotification() throws Exception {
+    void testHandleNotification() throws Exception {
         exporter.patterns = new String[] {"test:type=Test"};
         exporter.server = Mockito.mock(MBeanServer.class);
         MBeanInfo m = Mockito.mock(MBeanInfo.class);
@@ -41,7 +41,7 @@ public class JmxNotificationListenerTest {
         Mockito.when(notification.getType()).thenReturn("JMX.mbean.registered");
         ObjectName objectName = new ObjectName("test:type=Test");
         Mockito.when(notification.getMBeanName()).thenReturn(objectName);
-        Mockito.when(exporter.server.getMBeanInfo(Mockito.eq(objectName))).thenReturn(m);
+        Mockito.when(exporter.server.getMBeanInfo(objectName)).thenReturn(m);
         Mockito.when(m.getAttributes()).thenReturn(new javax.management.MBeanAttributeInfo[0]);
         listener.handleNotification(notification, null);
 

--- a/src/test/java/org/apache/sling/commons/metrics/internal/JmxUtilTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/JmxUtilTest.java
@@ -18,29 +18,28 @@
  */
 package org.apache.sling.commons.metrics.internal;
 
-import junit.framework.TestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class JmxUtilTest {
+class JmxUtilTest {
 
     @Test
-    public void quotation() throws Exception {
+    void quotation() {
         assertEquals("text", JmxUtil.quoteValueIfRequired("text"));
-        TestCase.assertEquals("", JmxUtil.quoteValueIfRequired(""));
+        assertEquals("", JmxUtil.quoteValueIfRequired(""));
         assertTrue(JmxUtil.quoteValueIfRequired("text*with?chars").startsWith("\""));
     }
 
     @Test
-    public void quoteAndComma() throws Exception {
+    void quoteAndComma() {
         assertTrue(JmxUtil.quoteValueIfRequired("text,withComma").startsWith("\""));
         assertTrue(JmxUtil.quoteValueIfRequired("text=withEqual").startsWith("\""));
     }
 
     @Test
-    public void safeDomainName() throws Exception {
+    void safeDomainName() {
         assertEquals("com.foo", JmxUtil.safeDomainName("com.foo"));
         assertEquals("com_foo", JmxUtil.safeDomainName("com:foo"));
         assertEquals("com_foo", JmxUtil.safeDomainName("com?foo"));

--- a/src/test/java/org/apache/sling/commons/metrics/internal/LogReporterTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/LogReporterTest.java
@@ -25,19 +25,24 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
 import junitx.util.PrivateAccessor;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class LogReporterTest {
+@ExtendWith(MockitoExtension.class)
+class LogReporterTest {
 
     @Mock
     private BundleContext bundleContext;
@@ -45,8 +50,9 @@ public class LogReporterTest {
     LogReporter reporterService = new LogReporter();
 
     @Test
-    public void testSpecificRegistryNameInclude() {
+    void testSpecificRegistryNameInclude() {
         MetricRegistry registry = new MetricRegistry();
+        @SuppressWarnings("unchecked")
         ServiceReference<MetricRegistry> registryServiceReference = mock(ServiceReference.class);
         when(bundleContext.getService(registryServiceReference)).thenReturn(registry);
         when(registryServiceReference.getProperty(MetricWebConsolePlugin.METRIC_REGISTRY_NAME))
@@ -68,8 +74,9 @@ public class LogReporterTest {
     }
 
     @Test
-    public void testSpecificRegistryNameExclude() {
+    void testSpecificRegistryNameExclude() {
         MetricRegistry registry = new MetricRegistry();
+        @SuppressWarnings("unchecked")
         ServiceReference<MetricRegistry> registryServiceReference = mock(ServiceReference.class);
         when(bundleContext.getService(registryServiceReference)).thenReturn(registry);
         when(registryServiceReference.getProperty(MetricWebConsolePlugin.METRIC_REGISTRY_NAME))
@@ -91,8 +98,9 @@ public class LogReporterTest {
     }
 
     @Test
-    public void testSpecificRegistryNameExcludeNullName() {
+    void testSpecificRegistryNameExcludeNullName() {
         MetricRegistry registry = new MetricRegistry();
+        @SuppressWarnings("unchecked")
         ServiceReference<MetricRegistry> registryServiceReference = mock(ServiceReference.class);
         when(bundleContext.getService(registryServiceReference)).thenReturn(registry);
 
@@ -112,8 +120,9 @@ public class LogReporterTest {
     }
 
     @Test
-    public void testLoggerName() throws Exception {
+    void testLoggerName() throws Exception {
         MetricRegistry registry = new MetricRegistry();
+        @SuppressWarnings("unchecked")
         ServiceReference<MetricRegistry> registryServiceReference = mock(ServiceReference.class);
         when(bundleContext.getService(registryServiceReference)).thenReturn(registry);
 
@@ -139,8 +148,9 @@ public class LogReporterTest {
     }
 
     @Test
-    public void testPrefix() throws Exception {
+    void testPrefix() throws Exception {
         MetricRegistry registry = new MetricRegistry();
+        @SuppressWarnings("unchecked")
         ServiceReference<MetricRegistry> registryServiceReference = mock(ServiceReference.class);
         when(bundleContext.getService(registryServiceReference)).thenReturn(registry);
 
@@ -165,8 +175,9 @@ public class LogReporterTest {
     }
 
     @Test
-    public void testPattern() throws Exception {
+    void testPattern() throws Exception {
         MetricRegistry registry = new MetricRegistry();
+        @SuppressWarnings("unchecked")
         ServiceReference<MetricRegistry> registryServiceReference = mock(ServiceReference.class);
         when(bundleContext.getService(registryServiceReference)).thenReturn(registry);
 
@@ -191,8 +202,9 @@ public class LogReporterTest {
     }
 
     @Test
-    public void testPrefixAndPattern() throws Exception {
+    void testPrefixAndPattern() throws Exception {
         MetricRegistry registry = new MetricRegistry();
+        @SuppressWarnings("unchecked")
         ServiceReference<MetricRegistry> registryServiceReference = mock(ServiceReference.class);
         when(bundleContext.getService(registryServiceReference)).thenReturn(registry);
 
@@ -217,17 +229,19 @@ public class LogReporterTest {
     }
 
     @Test
-    public void testRemove() {
+    void testRemove() {
         Slf4jReporter reporter = mock(Slf4jReporter.class);
         reporterService.removedService(null, reporter);
         verify(reporter, times(1)).close();
     }
 
     @Test
-    public void testNoOpCalls() {
-        // extra no-op calls for coverage
-        reporterService.removedService(null, null);
-        reporterService.modifiedService(null, null);
+    void testNoOpCalls() {
+        assertDoesNotThrow(() -> {
+            // extra no-op calls for coverage
+            reporterService.removedService(null, null);
+            reporterService.modifiedService(null, null);
+        });
     }
 
     private LogReporter.Config createConfigWithRegistryName(final String registryName) {

--- a/src/test/java/org/apache/sling/commons/metrics/internal/MetricServiceTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/MetricServiceTest.java
@@ -37,10 +37,11 @@ import org.apache.sling.commons.metrics.MetricsService;
 import org.apache.sling.commons.metrics.Timer;
 import org.apache.sling.testing.mock.osgi.MapUtil;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
-import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContext;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContextExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.ServiceRegistration;
 
 import static org.apache.sling.commons.metrics.internal.BundleMetricsMapper.JMX_TYPE_METRICS;
@@ -48,26 +49,27 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MetricServiceTest {
-    @Rule
+@ExtendWith(OsgiContextExtension.class)
+class MetricServiceTest {
     public final OsgiContext context = new OsgiContext();
 
     private MetricsServiceImpl service = new MetricsServiceImpl();
 
-    @After
-    public void deactivate() {
+    @AfterEach
+    void deactivate() {
         MockOsgi.deactivate(service, context.bundleContext());
     }
 
     @Test
-    public void defaultSetup() throws Exception {
+    void defaultSetup() {
         activate();
 
         assertNotNull(context.getService(MetricRegistry.class));
@@ -82,7 +84,7 @@ public class MetricServiceTest {
     }
 
     @Test
-    public void meter() throws Exception {
+    void meter() {
         activate();
         Meter meter = service.meter("test");
 
@@ -93,7 +95,7 @@ public class MetricServiceTest {
     }
 
     @Test
-    public void counter() throws Exception {
+    void counter() {
         activate();
         Counter counter = service.counter("test");
 
@@ -104,7 +106,7 @@ public class MetricServiceTest {
     }
 
     @Test
-    public void timer() throws Exception {
+    void timer() {
         activate();
         Timer timer = service.timer("test");
 
@@ -115,7 +117,7 @@ public class MetricServiceTest {
     }
 
     @Test
-    public void histogram() throws Exception {
+    void histogram() {
         activate();
         Histogram histo = service.histogram("test");
 
@@ -126,27 +128,27 @@ public class MetricServiceTest {
     }
 
     @Test
-    public void gaugeRegistration() throws Exception {
+    void gaugeRegistration() {
         activate();
         Gauge<Long> gauge = service.gauge("gauge", () -> 42L);
         assertNotNull(gauge);
         assertTrue(getRegistry().getGauges().containsKey("gauge"));
-        assertEquals(new Long(42L), gauge.getValue());
+        assertEquals(Long.valueOf(42L), gauge.getValue());
 
         // Just the name matters, not the supplier
         Gauge<?> gauge2 = service.gauge("gauge", () -> 43L);
         assertSame(gauge, gauge2);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void sameNameDifferentTypeMetric() throws Exception {
+    @Test
+    void sameNameDifferentTypeMetric() {
         activate();
         service.histogram("test");
-        service.timer("test");
+        assertThrows(IllegalArgumentException.class, () -> service.timer("test"));
     }
 
     @Test
-    public void jmxRegistration() throws Exception {
+    void jmxRegistration() throws Exception {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         activate();
         Meter meter = service.meter("test");
@@ -163,8 +165,9 @@ public class MetricServiceTest {
     }
 
     @Test
-    public void gaugeRegistrationViaWhiteboard() throws Exception {
+    void gaugeRegistrationViaWhiteboard() {
         activate();
+        @SuppressWarnings("rawtypes")
         ServiceRegistration<Gauge> reg = context.bundleContext()
                 .registerService(Gauge.class, new TestGauge(42), MapUtil.toDictionary(Gauge.NAME, "foo"));
 
@@ -176,7 +179,7 @@ public class MetricServiceTest {
     }
 
     @Test
-    public void unregisterMetric() {
+    void unregisterMetric() {
         activate();
         Gauge<Long> gauge = service.gauge("gauge", () -> 42L);
         assertNotNull(gauge);
@@ -193,7 +196,7 @@ public class MetricServiceTest {
         MockOsgi.activate(service, context.bundleContext(), Collections.<String, Object>emptyMap());
     }
 
-    private static class TestGauge implements Gauge {
+    private static class TestGauge implements Gauge<Object> {
         int value;
 
         public TestGauge(int value) {

--- a/src/test/java/org/apache/sling/commons/metrics/internal/MetricWebConsolePluginTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/MetricWebConsolePluginTest.java
@@ -30,29 +30,29 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.felix.inventory.Format;
 import org.apache.felix.utils.json.JSONParser;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.htmlunit.WebClient;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlTable;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MetricWebConsolePluginTest {
-    @Rule
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SlingContextExtension.class)
+class MetricWebConsolePluginTest {
     public final SlingContext context = new SlingContext();
 
     private MetricWebConsolePlugin plugin = new MetricWebConsolePlugin(context.bundleContext());
@@ -64,7 +64,7 @@ public class MetricWebConsolePluginTest {
     }
 
     @Test
-    public void consolidatedRegistry() {
+    void consolidatedRegistry() {
         MetricRegistry reg1 = new MetricRegistry();
         reg1.meter("test1");
         context.registerService(MetricRegistry.class, reg1, regProps("foo"));
@@ -103,7 +103,7 @@ public class MetricWebConsolePluginTest {
     }
 
     @Test
-    public void inventory_text() {
+    void inventory_text() {
         MetricRegistry reg1 = new MetricRegistry();
         reg1.meter("test1").mark(5);
         context.registerService(MetricRegistry.class, reg1, regProps("foo"));
@@ -121,7 +121,7 @@ public class MetricWebConsolePluginTest {
     }
 
     @Test
-    public void inventory_json() {
+    void inventory_json() {
         MetricRegistry reg1 = new MetricRegistry();
         reg1.meter("test1").mark(5);
         context.registerService(MetricRegistry.class, reg1, regProps("foo"));
@@ -138,7 +138,7 @@ public class MetricWebConsolePluginTest {
     }
 
     @Test
-    public void webConsolePlugin() throws Exception {
+    void webConsolePlugin() throws Exception {
         MetricRegistry reg1 = new MetricRegistry();
         reg1.meter("test1").mark(5);
         reg1.timer("test2").time().close();

--- a/src/test/java/org/apache/sling/commons/metrics/internal/MetricWrapperTest.java
+++ b/src/test/java/org/apache/sling/commons/metrics/internal/MetricWrapperTest.java
@@ -26,16 +26,16 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class MetricWrapperTest {
+class MetricWrapperTest {
     private MetricRegistry registry = new MetricRegistry();
 
     @Test
-    public void counter() throws Exception {
+    void counter() {
         Counter counter = registry.counter("test");
         CounterImpl counterStats = new CounterImpl(counter);
 
@@ -64,7 +64,7 @@ public class MetricWrapperTest {
     }
 
     @Test
-    public void meter() throws Exception {
+    void meter() {
         Meter meter = registry.meter("test");
         MeterImpl meterStats = new MeterImpl(meter);
 
@@ -79,7 +79,7 @@ public class MetricWrapperTest {
     }
 
     @Test
-    public void timer() throws Exception {
+    void timer() {
         Timer time = registry.timer("test");
         TimerImpl timerStats = new TimerImpl(time);
 
@@ -94,7 +94,7 @@ public class MetricWrapperTest {
     }
 
     @Test
-    public void histogram() throws Exception {
+    void histogram() {
         Histogram histo = registry.histogram("test");
         HistogramImpl histoStats = new HistogramImpl(histo);
 
@@ -107,7 +107,7 @@ public class MetricWrapperTest {
     }
 
     @Test
-    public void timerContext() throws Exception {
+    void timerContext() throws Exception {
         VirtualClock clock = new VirtualClock();
         Timer time = new Timer(new ExponentiallyDecayingReservoir(), clock);
 

--- a/src/test/java/org/apache/sling/commons/metrics/test/MetricsServiceFactoryIT.java
+++ b/src/test/java/org/apache/sling/commons/metrics/test/MetricsServiceFactoryIT.java
@@ -71,6 +71,7 @@ public class MetricsServiceFactoryIT extends TestSupport {
             MetricsServiceFactory.getMetricsService(null);
             fail("Expecting an Exception");
         } catch (IllegalArgumentException asExpected) {
+            // expected
         }
     }
 
@@ -80,6 +81,7 @@ public class MetricsServiceFactoryIT extends TestSupport {
             MetricsServiceFactory.getMetricsService(String.class);
             fail("Expecting an Exception");
         } catch (IllegalArgumentException asExpected) {
+            // expected
         }
     }
 


### PR DESCRIPTION
Migrate to junit 5 where possible.

NOTE: the paxexam based integration tests must stay on junit4 for now (use junit-vintage-engine)